### PR TITLE
New statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Mentor Statistics is an Chrome/Firefox extension that help you have more information on your incomes when you are an OpenClassRooms Mentor.
 This extension is only working for French mentors at the moment.
-With this extension you will have a new table on your mentorship sessions history with these values for the 2 last months:
+With this extension you will have a new tables on your mentorship sessions history with these values for the current and 2 last months:
 
-- Total number of mentoring sessions
-- Incomes by level
-- Total incomes
+- Total number of mentoring sessions (by level and total)
+- Total number of no-shows sessions (by level and total)
+- Global statistics (hourly average, mentoring hours, total income)
 
 ## Important about [OpenClassRooms](https://openclassrooms.com)
 

--- a/config/config.js
+++ b/config/config.js
@@ -17,9 +17,32 @@ var config = {
         "Niveau 1": "{0}€ - {1} session(s)",
         "Niveau 2": "{0}€ - {1} session(s)",
         "Niveau 3": "{0}€ - {1} session(s)",
-        Total: "{0}€ - {1} session(s)"
+        Revenus: "{0}€ - {1} session(s)"
       },
       update: "getTotalSessionsStats"
+    },
+    totalNoShows: {
+      idName: "totalNoShows",
+      title: "Total no-shows",
+      headers: {
+        Mois: "{0}",
+        "Niveau 1": "{0}€ - {1} session(s)",
+        "Niveau 2": "{0}€ - {1} session(s)",
+        "Niveau 3": "{0}€ - {1} session(s)",
+        Revenus: "{0}€ - {1} session(s)"
+      },
+      update: "getTotalNoShowsStats"
+    },
+    totalIncomes: {
+      idName: "totalIncomes",
+      title: "Total",
+      headers: {
+        Mois: "{0}",
+        "Moyenne horaire": "{0}€/h ({1}€/h sans no-shows)",
+        "Heures de mentorat": "{0}h et {1}h en no-shows",
+        Revenus: "{0}€ dont {1}€ en no-shows"
+      },
+      update: "getGlobalStatistics"
     }
   }
 };

--- a/config/config.js
+++ b/config/config.js
@@ -12,7 +12,13 @@ var config = {
     totalSessions: {
       idName: "totalSessions",
       title: "Total sessions",
-      headers: ["Mois", "Niveau 1", "Niveau 2", "Niveau 3", "Total"],
+      headers: {
+        Mois: "{0}",
+        "Niveau 1": "{0}€ - {1} session(s)",
+        "Niveau 2": "{0}€ - {1} session(s)",
+        "Niveau 3": "{0}€ - {1} session(s)",
+        Total: "{0}€ - {1} session(s)"
+      },
       update: "getTotalSessionsStats"
     }
   }

--- a/config/config.js
+++ b/config/config.js
@@ -7,5 +7,13 @@ var config = {
     "3": 40
   },
   months: DateUtils.getLastThreeMonths(),
-  stopMonth: DateUtils.getStopMonth()
+  stopMonth: DateUtils.getStopMonth(),
+  tablesConfig: {
+    totalSessions: {
+      idName: "totalSessions",
+      title: "Total sessions",
+      headers: ["Mois", "Niveau 1", "Niveau 2", "Niveau 3", "Total"],
+      update: "getTotalSessionsStats"
+    }
+  }
 };

--- a/config/config.js
+++ b/config/config.js
@@ -6,6 +6,6 @@ var config = {
     "2": 35,
     "3": 40
   },
-  months: [DateUtils.getCurrentMonth(), DateUtils.getPreviousMonth()],
+  months: DateUtils.getLastThreeMonths(),
   stopMonth: DateUtils.getStopMonth()
 };

--- a/libs/format.js
+++ b/libs/format.js
@@ -1,0 +1,20 @@
+String.prototype.format =
+  String.prototype.format ||
+  function() {
+    "use strict";
+    var str = this.toString();
+    if (arguments.length) {
+      var t = typeof arguments[0];
+      var key;
+      var args =
+        "string" === t || "number" === t
+          ? Array.prototype.slice.call(arguments)
+          : arguments[0];
+
+      for (key in args) {
+        str = str.replace(new RegExp("\\{" + key + "\\}", "gi"), args[key]);
+      }
+    }
+
+    return str;
+  };

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,7 @@
         "libs/jquery.tabletojson.js",
         "src/DateUtils.js",
         "config/config.js",
+        "src/SessionModel.js",
         "src/Price.js",
         "src/Statistics.js",
         "src/Display.js",

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
   "name": "Mentor Statistics OpenClassRooms",
-  "version": "1.0",
-  "description": "An extension that help you to have more informations on your incomes when you are an OpenClassRooms Mentor.",
+  "version": "1.1",
+  "description": "An extension that help you to have more statistics on your incomes when you are an OpenClassRooms Mentor.",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
       "js": [
         "libs/jquery-3.3.1.js",
         "libs/jquery.tabletojson.js",
+        "libs/format.js",
         "src/DateUtils.js",
         "config/config.js",
         "src/SessionModel.js",

--- a/src/DateUtils.js
+++ b/src/DateUtils.js
@@ -72,7 +72,7 @@ class DateUtils {
     var date = new Date();
 
     return DateUtils.getMonthList()[
-      date.getMonth() == 0 ? 10 : date.getMonth() - 2
+      date.getMonth() == 0 ? 9 : date.getMonth() - 3
     ];
   }
 }

--- a/src/DateUtils.js
+++ b/src/DateUtils.js
@@ -37,15 +37,31 @@ class DateUtils {
   }
 
   /**
-   * Return the previous month name.
-   * @static
+   * Return the month name (based on index) before current month.
+   * Example: Index = 1; Current month = February; Return (February - Index) = January.
+   * @param {int} index
    */
-  static getPreviousMonth() {
+  static getMonthFromCurrentMonth(index) {
     var date = new Date();
 
     return DateUtils.getMonthList()[
-      date.getMonth() == 0 ? 11 : date.getMonth() - 1
+      date.getMonth() == 0 ? 12 - index : date.getMonth() - index
     ];
+  }
+
+  /**
+   * Return the last three month names.
+   * @static
+   */
+  static getLastThreeMonths() {
+    var index = 0;
+    var monthList = [];
+
+    for (index; index < 3; index++) {
+      monthList.push(DateUtils.getMonthFromCurrentMonth(index));
+    }
+
+    return monthList;
   }
 
   /**

--- a/src/Display.js
+++ b/src/Display.js
@@ -24,36 +24,42 @@ class Display {
    * @param {string} month - A month name.
    * @param {Statistics} stats - Statistics object.
    */
-  createRow(month, stats) {
+  createRow(month, stats, tableConfig) {
     var row = $("<tr/>");
 
-    row.attr("id", "statisticsRow" + month);
-    $.each(stats.getStatisticsInArray(month), function(index, data) {
+    row.attr("id", tableConfig.idName + month);
+    $.each(stats[tableConfig.update](month), function(index, data) {
       row.append($("<td/>").text(data));
     });
 
     return row;
   }
 
-  /**
-   * Initialize the table with default values and headers.
-   * @param {*} container - DOM element selector.
-   * @param {Statistics} stats - Statistics object.
-   */
-  initializeTable(container, stats) {
+  createTable(container, stats, tableConfig) {
     var self = this;
+    var subContainer = $("<div/>").addClass("spacer-big");
     var table = $("<table/>")
       .addClass("crud-list")
-      .attr("id", "statisticsTable");
-    var headers = this.createColumnHeaders(stats.getStatisticsHeaders());
+      .attr("id", tableConfig.idName + "Table");
+    var headers = this.createColumnHeaders(tableConfig.headers);
     var row = undefined;
 
     table.append(headers);
     $.each(config.months, function(index, month) {
-      row = self.createRow(month, stats);
+      row = self.createRow(month, stats, tableConfig);
       table.append(row);
     });
-    container.prepend(table);
+    subContainer.prepend(table);
+    subContainer.prepend("<h2>" + tableConfig.title + "</h2>");
+    container.prepend(subContainer);
+  }
+
+  initializeTables(container, stats) {
+    var self = this;
+
+    $.each(config.tablesConfig, function(index, tableConfig) {
+      self.createTable(container, stats, tableConfig);
+    });
   }
 
   /**
@@ -62,8 +68,12 @@ class Display {
    * @param {Statistics} stats - Statistics object.
    */
   refreshRow(month, stats) {
-    var row = this.createRow(month, stats);
+    var self = this;
+    var row = undefined;
 
-    $("#statisticsRow" + month).replaceWith(row);
+    $.each(config.tablesConfig, function(index, tableConfig) {
+      row = self.createRow(month, stats, tableConfig);
+      $("#" + tableConfig.idName + month).replaceWith(row);
+    });
   }
 }

--- a/src/Display.js
+++ b/src/Display.js
@@ -71,10 +71,12 @@ class Display {
 
   initializeTables(mainContainer, stats) {
     var self = this;
+    var subContainer = $("<div/>").attr("id", "tablesContainer");
 
     $.each(config.tablesConfig, function(index, tableConfig) {
-      mainContainer.prepend(self.createTable(stats, tableConfig));
+      subContainer.append(self.createTable(stats, tableConfig));
     });
+    mainContainer.prepend(subContainer);
   }
 
   /**

--- a/src/Display.js
+++ b/src/Display.js
@@ -11,12 +11,25 @@ class Display {
     var headers = $("<thead/>");
 
     var row = $("<tr/>");
-    $.each(headersList, function(index, element) {
-      row.append($("<td/>").text(element));
+    $.each(headersList, function(key, format) {
+      row.append($("<td/>").text(key));
     });
     headers.append(row);
 
     return headers;
+  }
+
+  getFormattedRowData(month, stats, tableConfig) {
+    var rowData = stats[tableConfig.update](month);
+    var formattedRowData = [];
+    var index = 0;
+
+    $.each(tableConfig.headers, function(key, value) {
+      formattedRowData.push(value.format(rowData[index]));
+      index++;
+    });
+
+    return formattedRowData;
   }
 
   /**
@@ -26,39 +39,41 @@ class Display {
    */
   createRow(month, stats, tableConfig) {
     var row = $("<tr/>");
+    var data = stats[tableConfig.update](month);
+    var formattedRowData = this.getFormattedRowData(month, stats, tableConfig);
 
     row.attr("id", tableConfig.idName + month);
-    $.each(stats[tableConfig.update](month), function(index, data) {
+    $.each(formattedRowData, function(index, data) {
       row.append($("<td/>").text(data));
     });
 
     return row;
   }
 
-  createTable(container, stats, tableConfig) {
+  createTable(stats, tableConfig) {
     var self = this;
     var subContainer = $("<div/>").addClass("spacer-big");
     var table = $("<table/>")
       .addClass("crud-list")
       .attr("id", tableConfig.idName + "Table");
     var headers = this.createColumnHeaders(tableConfig.headers);
-    var row = undefined;
 
     table.append(headers);
     $.each(config.months, function(index, month) {
-      row = self.createRow(month, stats, tableConfig);
-      table.append(row);
+      table.append(self.createRow(month, stats, tableConfig));
     });
+
     subContainer.prepend(table);
-    subContainer.prepend("<h2>" + tableConfig.title + "</h2>");
-    container.prepend(subContainer);
+    subContainer.prepend($("<h2>").text(tableConfig.title));
+
+    return subContainer;
   }
 
-  initializeTables(container, stats) {
+  initializeTables(mainContainer, stats) {
     var self = this;
 
     $.each(config.tablesConfig, function(index, tableConfig) {
-      self.createTable(container, stats, tableConfig);
+      mainContainer.prepend(self.createTable(stats, tableConfig));
     });
   }
 

--- a/src/SessionModel.js
+++ b/src/SessionModel.js
@@ -1,0 +1,5 @@
+class SessionModel {
+  constructor() {
+    (this.type = 0), (this.month = ""), (this.level = ""), (this.income = 0);
+  }
+}

--- a/src/SessionModel.js
+++ b/src/SessionModel.js
@@ -1,4 +1,12 @@
+/**
+ * Class model for a mentoring session.
+ * @class
+ */
 class SessionModel {
+  /**
+   * Initialization of required variables.
+   * @constructor
+   */
   constructor() {
     (this.type = 0), (this.month = ""), (this.level = ""), (this.income = 0);
   }

--- a/src/Statistics.js
+++ b/src/Statistics.js
@@ -8,42 +8,53 @@ class Statistics {
    * @constructor
    */
   constructor() {
-    this.sessionsNb = new Array();
-    this.sessionsIncomes = new Array();
+    this.normalIncomes = new Array();
+    this.canceledIncomes = new Array();
+    this.normalNb = new Array();
+    this.canceledNb = new Array();
+    this.sessionTypes = ["normal", "canceled"];
   }
 
   /**
-   * Initialize sessions number array and sessions incomes array.
+   *
+   * @param {SessionModel} session
+   */
+  addSession(session) {
+    var sessionType =
+      session.type == -1 ? this.sessionTypes[0] : this.sessionTypes[1];
+
+    this[sessionType + "Nb"][session.month][session.level] += 1;
+    this[sessionType + "Incomes"][session.month][session.level] +=
+      session.income;
+  }
+
+  /**
+   * Initialize a variable of the class by it's name.
+   * @param {string} variableName - Class variable name
+   * @param {string} month - A month name
+   */
+  initializeVariableByName(variableName, month) {
+    var defaultValues = {
+      "1": 0,
+      "2": 0,
+      "3": 0
+    };
+
+    this[variableName][month] = defaultValues;
+  }
+
+  /**
+   * Initialize sessions number arrays and sessions incomes arrays.
    */
   initialize() {
     var self = this;
 
-    $.each(config.months, function(index, month) {
-      self.sessionsIncomes[month] = {
-        "1": 0,
-        "2": 0,
-        "3": 0
-      };
-      self.sessionsNb[month] = 0;
+    $.each(config.months, function(mIndex, month) {
+      $.each(self.sessionTypes, function(mType, type) {
+        self.initializeVariableByName(type + "Nb", month);
+        self.initializeVariableByName(type + "Incomes", month);
+      });
     });
-  }
-
-  /**
-   * Add 1 to current session number of the month.
-   * @param {string} month - A month name.
-   */
-  incrementSessionsNb(month) {
-    this.sessionsNb[month] += 1;
-  }
-
-  /**
-   * Add income of a session.
-   * @param {string} month - A month name.
-   * @param {string} level - The level of session.
-   * @param {int} income - The income of session.
-   */
-  addSessionIncome(month, level, income) {
-    this.sessionsIncomes[month][level] += income;
   }
 
   /**
@@ -60,37 +71,22 @@ class Statistics {
    */
   getTotalIncome(month) {
     return (
-      this.sessionsIncomes[month]["1"] +
-      this.sessionsIncomes[month]["2"] +
-      this.sessionsIncomes[month]["3"]
+      this["normalIncomes"][month]["1"] +
+      this["normalIncomes"][month]["2"] +
+      this["normalIncomes"][month]["3"]
     );
-  }
-
-  /**
-   * Return an array with statistics headers (table headers).
-   */
-  getStatisticsHeaders() {
-    return [
-      "Mois",
-      "Total sessions",
-      "Niveau 1",
-      "Niveau 2",
-      "Niveau 3",
-      "Revenu total"
-    ];
   }
 
   /**
    * Return an array with all statistics (in order of headers).
    * @param {string} month - A month name.
    */
-  getStatisticsInArray(month) {
+  getTotalSessionsStats(month) {
     return [
       month,
-      this.sessionsNb[month],
-      this.sessionsIncomes[month]["1"] + "€",
-      this.sessionsIncomes[month]["2"] + "€",
-      this.sessionsIncomes[month]["3"] + "€",
+      this["normalIncomes"][month]["1"] + "€",
+      this["normalIncomes"][month]["2"] + "€",
+      this["normalIncomes"][month]["3"] + "€",
       this.getTotalIncome(month) + "€"
     ];
   }

--- a/src/Statistics.js
+++ b/src/Statistics.js
@@ -66,15 +66,34 @@ class Statistics {
   }
 
   /**
-   * Return total income of a month.
+   * Return month total informations (income + number of sessions) by level.
    * @param {string} month - A month name.
+   * @param {string} type - Type of session (normal or canceled).
    */
-  getTotalIncome(month) {
-    return (
-      this["normalIncomes"][month]["1"] +
-      this["normalIncomes"][month]["2"] +
-      this["normalIncomes"][month]["3"]
-    );
+  getMonthTotalInfosByType(month, type) {
+    var incomeType = type + "Incomes";
+    var nbType = type + "Nb";
+
+    return [
+      this[incomeType][month]["1"] +
+        this[incomeType][month]["2"] +
+        this[incomeType][month]["3"],
+      this[nbType][month]["1"] +
+        this[nbType][month]["2"] +
+        this[nbType][month]["3"]
+    ];
+  }
+
+  /**
+   * Return month level informations (income + number of sessions) by level.
+   * @param {string} month - A month name.
+   * @param {string} type - Type of session (normal or canceled).
+   */
+  getMonthLevelInfosByType(month, type, level) {
+    return [
+      this[type + "Incomes"][month][level],
+      this[type + "Nb"][month][level]
+    ];
   }
 
   /**
@@ -84,10 +103,10 @@ class Statistics {
   getTotalSessionsStats(month) {
     return [
       month,
-      this["normalIncomes"][month]["1"] + "€",
-      this["normalIncomes"][month]["2"] + "€",
-      this["normalIncomes"][month]["3"] + "€",
-      this.getTotalIncome(month) + "€"
+      this.getMonthLevelInfosByType(month, "normal", "1"),
+      this.getMonthLevelInfosByType(month, "normal", "2"),
+      this.getMonthLevelInfosByType(month, "normal", "3"),
+      this.getMonthTotalInfosByType(month, "normal")
     ];
   }
 }

--- a/src/Statistics.js
+++ b/src/Statistics.js
@@ -16,7 +16,7 @@ class Statistics {
   }
 
   /**
-   *
+   * Add a session model to statistics.
    * @param {SessionModel} session
    */
   addSession(session) {
@@ -58,14 +58,6 @@ class Statistics {
   }
 
   /**
-   * Return number of sessions on a month.
-   * @param {string} month - A month name.
-   */
-  getSessionsNb(month) {
-    return this.sessionsNb[month];
-  }
-
-  /**
    * Return month total informations (income + number of sessions) by level.
    * @param {string} month - A month name.
    * @param {string} type - Type of session (normal or canceled).
@@ -97,7 +89,50 @@ class Statistics {
   }
 
   /**
-   * Return an array with all statistics (in order of headers).
+   * Return total income by type of a month;
+   * @param {string} month - A month name.
+   * @param {string} type - Type of session (normal or canceled).
+   */
+  getTotalIncome(month, type) {
+    var totalIncome = 0;
+    var nbType = type + "Incomes";
+
+    for (var i = 1; i < 4; i++) {
+      totalIncome += this[nbType][month][i];
+    }
+    return totalIncome;
+  }
+
+  /**
+   * Return total hours by type of a month;
+   * @param {string} month - A month name.
+   * @param {string} type - Type of session (normal or canceled).
+   */
+  getTotalHours(month, type) {
+    var totalHours = 0;
+    var nbType = type + "Nb";
+
+    for (var i = 1; i < 4; i++) {
+      totalHours += this[nbType][month][i];
+    }
+    return totalHours;
+  }
+
+  /**
+   * Return average income by hours.
+   * @param {int} totalIncome
+   * @param {int} totalHours
+   */
+  getAverageIncome(totalIncome, totalHours) {
+    if (totalHours === 0 || isNaN(totalHours)) {
+      return 0;
+    } else {
+      return (totalIncome / totalHours).toFixed(2);
+    }
+  }
+
+  /**
+   * Return an array with all sessions tatistics (in order of headers).
    * @param {string} month - A month name.
    */
   getTotalSessionsStats(month) {
@@ -107,6 +142,44 @@ class Statistics {
       this.getMonthLevelInfosByType(month, "normal", "2"),
       this.getMonthLevelInfosByType(month, "normal", "3"),
       this.getMonthTotalInfosByType(month, "normal")
+    ];
+  }
+
+  /**
+   * Return an array with all no-shows statistics (in order of headers).
+   * @param {string} month - A month name.
+   */
+  getTotalNoShowsStats(month) {
+    return [
+      month,
+      this.getMonthLevelInfosByType(month, "canceled", "1"),
+      this.getMonthLevelInfosByType(month, "canceled", "2"),
+      this.getMonthLevelInfosByType(month, "canceled", "3"),
+      this.getMonthTotalInfosByType(month, "canceled")
+    ];
+  }
+
+  /**
+   * Return an array with all global statistics (in order of headers).
+   * @param {string} month - A month name.
+   */
+  getGlobalStatistics(month) {
+    var totalSessionIncome = this.getTotalIncome(month, "normal");
+    var totalNoShowsIncome = this.getTotalIncome(month, "canceled");
+    var totalSessionsNb = this.getTotalHours(month, "normal");
+    var totalNoShowsNb = this.getTotalHours(month, "canceled");
+
+    return [
+      month,
+      [
+        this.getAverageIncome(
+          totalSessionIncome + totalNoShowsIncome,
+          totalSessionsNb + totalNoShowsNb
+        ),
+        this.getAverageIncome(totalSessionIncome, totalSessionsNb)
+      ],
+      [totalSessionsNb, totalNoShowsNb],
+      [totalSessionIncome + totalNoShowsIncome, totalNoShowsIncome]
     ];
   }
 }


### PR DESCRIPTION
New tables on mentorship sessions history with these values for the current and 2 last months:

- Total number of mentoring sessions (by level and total)
- Total number of no-shows sessions (by level and total)
- Global statistics (hourly average, mentoring hours, total income)

Better configuration file. It's now more easy to create new table with new statistics.

[Related issue](https://github.com/gael-thomas/Mentor-Statistics-OpenClassRooms/issues/1#issue-430175478)