### PR TITLE
Fix calculation of the index of previous months

### DIFF
--- a/src/DateUtils.js
+++ b/src/DateUtils.js
@@ -45,7 +45,7 @@ class DateUtils {
     var date = new Date();
 
     return DateUtils.getMonthList()[
-      date.getMonth() == 0 ? 12 - index : date.getMonth() - index
+      (12 + date.getMonth() - index)%12
     ];
   }
 


### PR DESCRIPTION
Use modulos in order to calculate the index of the previous months instead of current method.

This fixes display of "{0}" in months list instead of "Janvier"